### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-ignore-filter.gemspec
+++ b/fluent-plugin-ignore-filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", ">= 0.12"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/filter_ignore.rb
+++ b/lib/fluent/plugin/filter_ignore.rb
@@ -1,4 +1,6 @@
-module Fluent
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
   class IgnoreFilter < Filter
     Fluent::Plugin.register_filter('ignore', self)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|

--- a/test/plugin/test_filter_ignore.rb
+++ b/test/plugin/test_filter_ignore.rb
@@ -6,7 +6,7 @@ class IgnoreFilterTest < Test::Unit::TestCase
   end
 
   def create_driver(conf='')
-    Fluent::Test::FilterTestDriver.new(Fluent::IgnoreFilter).configure(conf, true)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::IgnoreFilter).configure(conf)
   end
 
   def test_configure_default
@@ -23,28 +23,28 @@ class IgnoreFilterTest < Test::Unit::TestCase
   def test_emit
     d1 = create_driver(%[regexp1 level info])
 
-    d1.run do
-      d1.emit({'level'=>'info','ident'=>'kernel','server_name'=>'prod-web','message'=>'some info'})
-      d1.emit({'level'=>'warn','ident'=>'kernel','server_name'=>'prod-web','message'=>'failed to do something'})
+    d1.run(default_tag: 'test') do
+      d1.feed({'level'=>'info','ident'=>'kernel','server_name'=>'prod-web','message'=>'some info'})
+      d1.feed({'level'=>'warn','ident'=>'kernel','server_name'=>'prod-web','message'=>'failed to do something'})
     end
 
-    emits = d1.emits
+    filtered = d1.filtered
 
-    assert_equal(1, emits.length)
-    assert_equal('warn', emits[0][2]['level'])
+    assert_equal(1, filtered.length)
+    assert_equal('warn', filtered[0][1]['level'])
   end
 
   def test_emit_removebyident
     d1 = create_driver(%[regexp1 ident kernel])
 
-    d1.run do
-      d1.emit({'level'=>'info','ident'=>'kernel'})
-      d1.emit({'level'=>'warn','ident'=>'kernel'})
+    d1.run(default_tag: 'test') do
+      d1.feed({'level'=>'info','ident'=>'kernel'})
+      d1.feed({'level'=>'warn','ident'=>'kernel'})
     end
 
-    emits = d1.emits
+    filtered = d1.filtered
 
-    assert_equal(0, emits.length)
+    assert_equal(0, filtered.length)
   end
 
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.